### PR TITLE
Support for eZ Platform

### DIFF
--- a/Core/Persistence/Legacy/Content/FieldValue/Converter/UniqueTextLineConverter.php
+++ b/Core/Persistence/Legacy/Content/FieldValue/Converter/UniqueTextLineConverter.php
@@ -2,7 +2,7 @@
 
 namespace Eab\UniqueDatatypesBundle\Core\Persistence\Legacy\Content\FieldValue\Converter;
 
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLine as TextLineConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\TextLineConverter;
 
 /**
  * UniqueTextLine field value converter class

--- a/Core/Persistence/Legacy/Content/FieldValue/Converter/UniqueUrlConverter.php
+++ b/Core/Persistence/Legacy/Content/FieldValue/Converter/UniqueUrlConverter.php
@@ -2,7 +2,7 @@
 
 namespace Eab\UniqueDatatypesBundle\Core\Persistence\Legacy\Content\FieldValue\Converter;
 
-use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Url as UrlConverter;
+use eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\UrlConverter;
 
 /**
  * UniqueUrl field value converter class

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         { "name": "Enterprise AB Ltd", "homepage": "http://eab.uk" }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "*"
+        "ezsystems/ezpublish-kernel": "~6.0"
     },
     "autoload": {
         "psr-4": { "Eab\\UniqueDatatypesBundle\\": "" }


### PR DESCRIPTION
Currently this bundle does not supports eZ Platform. This PR makes bundle works on ezpublish kernel > 6.0.

I suggest that you release version 2.0 of this bundle with this fix, as it breaks backward compatibility.

For detailed info please check https://github.com/ezsystems/ezpublish-kernel/commit/cfe2136a8481351f598a9b26e792de89cf5b03e7.