### PR TITLE
Suggest legacy extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
     "require": {
         "ezsystems/ezpublish-kernel": "*"
     },
+    "suggest": {
+        "eab/ezuniquedatatypes": "To edit this field type in legacy administration interface"
+    },
     "autoload": {
         "psr-4": { "Eab\\UniqueDatatypesBundle\\": "" }
     }


### PR DESCRIPTION
Please add legacy extension https://github.com/eab-dev/ezuniquedatatypes to packagist as `eab/ezuniquedatatypes` it will make installation and use of current extension much easier.