### PR TITLE
Field template override

### DIFF
--- a/Resources/config/templates.yml
+++ b/Resources/config/templates.yml
@@ -1,4 +1,4 @@
 system:
-    global:
+    default:
         field_templates:
-            - {template: EabUniqueDatatypesBundle:content_fields.html, priority: 0}
+            - { template: EabUniqueDatatypesBundle:content_fields.html, priority: 0 }

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,9 @@
     "require": {
         "ezsystems/ezpublish-kernel": "*"
     },
+    "suggest": {
+        "eab/ezuniquedatatypes": "To edit this field type in legacy administration interface"
+    },
     "autoload": {
         "psr-4": { "Eab\\UniqueDatatypesBundle\\": "" }
     }


### PR DESCRIPTION
`default` override should be used instead of `global` for reusable bundles.