### PR TITLE
Support for eZ Platform 2.0 (ezpublish-kernel 7.x)

### DIFF
--- a/DependencyInjection/EabUniqueDatatypesExtension.php
+++ b/DependencyInjection/EabUniqueDatatypesExtension.php
@@ -37,7 +37,7 @@ class EabUniqueDatatypesExtension extends Extension implements PrependExtensionI
      */
     public function prepend( ContainerBuilder $container )
     {
-        $configFile = __DIR__ . '/../Resources/config/templates.yml';
+        $configFile = __DIR__ . '/../Resources/config/ezpublish.yml';
         $config = Yaml::parse( file_get_contents( $configFile ) );
         $container->prependExtensionConfig( 'ezpublish', $config );
         $container->addResource( new FileResource( $configFile ) );

--- a/Resources/config/ezpublish.yml
+++ b/Resources/config/ezpublish.yml
@@ -1,0 +1,4 @@
+system:
+    default:
+        field_templates:
+            - {template: '@EabUniqueDatatypes/content_fields.html.twig', priority: 0}

--- a/Resources/config/fieldtypes.yml
+++ b/Resources/config/fieldtypes.yml
@@ -5,23 +5,23 @@ parameters:
 
 services:
     ezpublish.fieldType.ezuniquestring:
-        class: %ezpublish.fieldType.ezuniquestring.class%
+        class: "%ezpublish.fieldType.ezuniquestring.class%"
         parent: ezpublish.fieldType
         tags:
             - { name: ezpublish.fieldType, alias: ezuniquestring }
     ezpublish.fieldType.ezuniqueurl:
-        class: %ezpublish.fieldType.ezuniqueurl.class%
+        class: "%ezpublish.fieldType.ezuniqueurl.class%"
         parent: ezpublish.fieldType
         tags:
             - { name: ezpublish.fieldType, alias: ezuniqueurl }
     ezpublish.fieldType.ezuniqueurl.externalStorage:
-        class: %ezpublish.fieldType.ezurl.externalStorage.class%
+        class: "%ezpublish.fieldType.ezurl.externalStorage.class%"
         arguments:
             - []
-            - @?logger
+            - "@?logger"
         tags:
             - { name: ezpublish.fieldType.externalStorageHandler, alias: ezuniqueurl }
     ezpublish.fieldType.ezuniqueurl.storage_gateway:
-        class: %ezpublish.fieldType.ezurl.storage_gateway.class%
+        class: "%ezpublish.fieldType.ezurl.storage_gateway.class%"
         tags:
             - { name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezuniqueurl, identifier: LegacyStorage }

--- a/Resources/config/fieldtypes.yml
+++ b/Resources/config/fieldtypes.yml
@@ -25,3 +25,13 @@ services:
         class: "%ezpublish.fieldType.ezurl.storage_gateway.class%"
         tags:
             - { name: ezpublish.fieldType.externalStorageHandler.gateway, alias: ezuniqueurl, identifier: LegacyStorage }
+
+    ezpublish.fieldtype.indexable.ezuniquestring:
+        class: "%ezpublish.fieldType.indexable.ezstring.class%"
+        tags:
+            - {name: ezpublish.fieldType.indexable, alias: ezuniquestring}
+
+    ezpublish.fieldtype.indexable.ezuniqueurl:
+        class: "%ezpublish.fieldType.indexable.ezurl.class%"
+        tags:
+            - {name: ezpublish.fieldType.indexable, alias: ezuniqueurl}

--- a/Resources/config/storage_engines.yml
+++ b/Resources/config/storage_engines.yml
@@ -4,10 +4,10 @@ parameters:
 
 services:
     ezpublish.fieldType.ezuniquestring.converter:
-        class: %ezpublish.fieldType.ezuniquestring.converter.class%
+        class: "%ezpublish.fieldType.ezuniquestring.converter.class%"
         tags:
             - {name: ezpublish.storageEngine.legacy.converter, alias: ezuniquestring, lazy: true, callback: "::create"}
     ezpublish.fieldType.ezuniqueurl.converter:
-        class: %ezpublish.fieldType.ezuniqueurl.converter.class%
+        class: "%ezpublish.fieldType.ezuniqueurl.converter.class%"
         tags:
             - {name: ezpublish.storageEngine.legacy.converter, alias: ezuniqueurl, lazy: true, callback: "::create"}

--- a/Resources/config/templates.yml
+++ b/Resources/config/templates.yml
@@ -1,4 +1,0 @@
-system:
-    default:
-        field_templates:
-            - { template: EabUniqueDatatypesBundle:content_fields.html, priority: 0 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         { "name": "Enterprise AB Ltd", "homepage": "http://eab.uk" }
     ],
     "require": {
-        "ezsystems/ezpublish-kernel": "~6.0"
+        "ezsystems/ezpublish-kernel": "^6.0|7.0"
     },
     "suggest": {
         "eab/ezuniquedatatypes": "To edit this field type in legacy administration interface"


### PR DESCRIPTION
This enables bundle to work on ezpublish kernel 7.x  Also with this PR content types are indexible so it will work with [ezplatform-solr-search-engine](https://github.com/ezsystems/ezplatform-solr-search-engine).